### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up Airbyte connector"
-description: "C1 provides identity governance and just-in-time provisioning for Airbyte. Integrate your Airbyte instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Airbyte. Integrate your Airbyte instance with C1 for unified visibility and governance over user access."
 og:title: "Set up Airbyte connector"
-og:description: "C1 provides identity governance and just-in-time provisioning for Airbyte. Integrate your Airbyte instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance for Airbyte. Integrate your Airbyte instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Airbyte"
 ---
 
@@ -33,7 +33,7 @@ Each setup method requires you to pass in credentials generated in Airbyte. Gath
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Airbyte connector
 
@@ -86,7 +86,7 @@ Each setup method requires you to pass in credentials generated in Airbyte. Gath
     </Step>
 </Steps>
 
-**That's it!** Your Airbyte connector is now pulling access data into C1.
+**Done.** Your Airbyte connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Airbyte connector, hosted and run in your own environment.**
@@ -199,7 +199,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Airbyte connector is now pulling access data into C1.
+**Done.** Your Airbyte connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines