### PR TITLE
fix: mark credential fields secret

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var Config = field.NewConfiguration(
 			"airbyte-client-secret",
 			field.WithRequired(true),
 			field.WithDescription("The Airbyte client secret used to connect to the Airbyte API."),
+			field.WithIsSecret(true),
 		),
 	},
 	field.WithConstraints(


### PR DESCRIPTION
Marks the `airbyte-client-secret` OAuth client secret as secret so the value is obscured in the UI and kept out of plain-text storage.

**Breaking change:** existing plain-text configs will need the `airbyte-client-secret` value re-entered after upgrade.

_(satellite) Built with stargate._