### PR TITLE
[CXH-1872] containerize connector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
-GENERATED_CONF = pkg/config/conf.gen.go
+GENERATED_CONF := pkg/config/conf.gen.go
 
 ifeq ($(GOOS),windows)
 OUTPUT_PATH = ${BUILD_DIR}/baton-airbyte.exe
@@ -9,16 +9,22 @@ else
 OUTPUT_PATH = ${BUILD_DIR}/baton-airbyte
 endif
 
+# Set the build tag conditionally based on BATON_LAMBDA_SUPPORT
+ifdef BATON_LAMBDA_SUPPORT
+	BUILD_TAGS=-tags baton_lambda_support
+else
+	BUILD_TAGS=
+endif
+
 .PHONY: build
 build: $(GENERATED_CONF)
-	go build -o ${OUTPUT_PATH} ./cmd/baton-airbyte
+	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-airbyte
 
 $(GENERATED_CONF): pkg/config/config.go go.mod
+	@echo "Generating $(GENERATED_CONF)..."
 	go generate ./pkg/config
 
-.PHONY: generate
-generate:
-	go generate ./pkg/config
+generate: $(GENERATED_CONF)
 
 .PHONY: update-deps
 update-deps:

--- a/cmd/baton-airbyte/main.go
+++ b/cmd/baton-airbyte/main.go
@@ -2,17 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-airbyte/pkg/config"
 	"github.com/conductorone/baton-airbyte/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var version = "dev"
@@ -20,51 +14,12 @@ var version = "dev"
 func main() {
 	ctx := context.Background()
 
-	_, cmd, err := config.DefineConfiguration(
+	config.RunConnector(
 		ctx,
 		"baton-airbyte",
-		getConnector,
+		version,
 		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Airbyte{}),
+		connector.NewLambdaConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Airbyte{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, ac *cfg.Airbyte) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	if err := cfg.ValidateConfig(ac); err != nil {
-		return nil, err
-	}
-
-	cb, err := connector.New(ctx, ac.Hostname, ac.AirbyteClientId, ac.AirbyteClientSecret)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	// Test the connector by validating it
-	if _, err := cb.Validate(ctx); err != nil {
-		l.Error("error validating connector", zap.Error(err))
-		return nil, err
-	}
-
-	c, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return c, nil
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -94,7 +94,9 @@
     },
     {
       "name": "hostname",
+      "displayName": "Airbyte hostname",
       "description": "The Airbyte hostname used to connect to the Airbyte API",
+      "placeholder": "Your Airbyte hostname",
       "isRequired": true,
       "stringField": {
         "rules": {
@@ -104,8 +106,11 @@
     },
     {
       "name": "airbyte-client-id",
-      "description": "The Airbyte client id used to connect to the Airbyte API.",
+      "displayName": "Airbyte client ID",
+      "description": "The Airbyte client ID used to connect to the Airbyte API.",
+      "placeholder": "Your Airbyte client ID",
       "isRequired": true,
+      "isSecret": true,
       "stringField": {
         "rules": {
           "isRequired": true
@@ -114,7 +119,9 @@
     },
     {
       "name": "airbyte-client-secret",
+      "displayName": "Airbyte client secret",
       "description": "The Airbyte client secret used to connect to the Airbyte API.",
+      "placeholder": "Your Airbyte client secret",
       "isRequired": true,
       "isSecret": true,
       "stringField": {
@@ -124,13 +131,7 @@
       }
     }
   ],
-  "constraints": [
-    {
-      "kind": "CONSTRAINT_KIND_REQUIRED_TOGETHER",
-      "fieldNames": [
-        "airbyte-client-id",
-        "airbyte-client-secret"
-      ]
-    }
-  ]
+  "displayName": "Airbyte",
+  "helpUrl": "/docs/baton/airbyte",
+  "iconUrl": "/static/app-icons/airbyte.svg"
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -150,7 +150,7 @@ stringData:
   # Airbyte credentials
   BATON_AIRBYTE_CLIENT_ID: <Airbyte client ID>
   BATON_AIRBYTE_CLIENT_SECRET: <Airbyte client secret>
-  BATON_DOMAIN_URL: <URL of your Airbyte instance, such as https://cloud.airbyte.com>
+  BATON_HOSTNAME: <URL of your Airbyte instance, such as https://cloud.airbyte.com>
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,33 +6,39 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
-var Config = field.NewConfiguration(
-	[]field.SchemaField{
-		field.StringField(
-			"hostname",
-			field.WithRequired(true),
-			field.WithDescription("The Airbyte hostname used to connect to the Airbyte API"),
-		),
-		field.StringField(
-			"airbyte-client-id",
-			field.WithRequired(true),
-			field.WithDescription("The Airbyte client id used to connect to the Airbyte API."),
-		),
-		field.StringField(
-			"airbyte-client-secret",
-			field.WithRequired(true),
-			field.WithDescription("The Airbyte client secret used to connect to the Airbyte API."),
-			field.WithIsSecret(true),
-		),
-	},
-	field.WithConstraints(
-		field.FieldsRequiredTogether(
-			field.StringField("airbyte-client-id"),
-			field.StringField("airbyte-client-secret"),
-		),
-	),
+var (
+	hostnameField = field.StringField(
+		"hostname",
+		field.WithRequired(true),
+		field.WithDisplayName("Airbyte hostname"),
+		field.WithDescription("The Airbyte hostname used to connect to the Airbyte API"),
+		field.WithPlaceholder("Your Airbyte hostname"),
+	)
+	clientIDField = field.StringField(
+		"airbyte-client-id",
+		field.WithRequired(true),
+		field.WithDisplayName("Airbyte client ID"),
+		field.WithDescription("The Airbyte client ID used to connect to the Airbyte API."),
+		field.WithPlaceholder("Your Airbyte client ID"),
+		field.WithIsSecret(true),
+	)
+	clientSecretField = field.StringField(
+		"airbyte-client-secret",
+		field.WithRequired(true),
+		field.WithDisplayName("Airbyte client secret"),
+		field.WithDescription("The Airbyte client secret used to connect to the Airbyte API."),
+		field.WithPlaceholder("Your Airbyte client secret"),
+		field.WithIsSecret(true),
+	)
 )
 
-func ValidateConfig(c *Airbyte) error {
-	return nil
-}
+var Config = field.NewConfiguration(
+	[]field.SchemaField{
+		hostnameField,
+		clientIDField,
+		clientSecretField,
+	},
+	field.WithConnectorDisplayName("Airbyte"),
+	field.WithIconUrl("/static/app-icons/airbyte.svg"),
+	field.WithHelpUrl("/docs/baton/airbyte"),
+)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io"
 
-	cfg "github.com/conductorone/baton-airbyte/pkg/config"
 	"github.com/conductorone/baton-airbyte/pkg/airbyte"
+	cfg "github.com/conductorone/baton-airbyte/pkg/config"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/cli"

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"io"
 
+	cfg "github.com/conductorone/baton-airbyte/pkg/config"
 	"github.com/conductorone/baton-airbyte/pkg/airbyte"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -18,8 +20,8 @@ type Airbyte struct {
 }
 
 // ResourceSyncers returns a list of syncers for different resource types.
-func (a *Airbyte) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+func (a *Airbyte) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newOrgBuilder(a.client),
 		newUserBuilder(a.client),
 		newWorkspaceBuilder(a.client),
@@ -66,4 +68,13 @@ func New(ctx context.Context, hostname string, clientId string, clientSecret str
 	return &Airbyte{
 		client: airbyteClient,
 	}, nil
+}
+
+// NewLambdaConnector satisfies cli.NewConnector for use with config.RunConnector.
+func NewLambdaConnector(ctx context.Context, ac *cfg.Airbyte, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	cb, err := New(ctx, ac.Hostname, ac.AirbyteClientId, ac.AirbyteClientSecret)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cb, nil, nil
 }

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/conductorone/baton-airbyte/pkg/airbyte"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -59,10 +57,10 @@ func orgResource(org airbyte.Organization) (*v2.Resource, error) {
 }
 
 // List returns all the organizations.
-func (o *orgBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *orgBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	orgs, err := o.client.ListOrganizations(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("airbyte-connector: failed to list organizations: %w", err)
+		return nil, nil, fmt.Errorf("airbyte-connector: failed to list organizations: %w", err)
 	}
 
 	// Iterate over organizations and filter valid ones
@@ -75,17 +73,17 @@ func (o *orgBuilder) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.T
 		// Convert organization to a v2.Resource
 		resource, err := orgResource(org)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("failed to create resource for organization %s: %w", org.Name, err)
+			return nil, nil, fmt.Errorf("failed to create resource for organization %s: %w", org.Name, err)
 		}
 
 		resources = append(resources, resource)
 	}
 
-	return resources, "", nil, nil
+	return resources, nil, nil
 }
 
 // Entitlements returns a slice of entitlements for possible user roles under organization.
-func (o *orgBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *orgBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	// Preallocate slice for efficiency
 	entitlements := make([]*v2.Entitlement, 0, len(PublicOrganizationPermissionsTypes))
 
@@ -105,14 +103,14 @@ func (o *orgBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *p
 		entitlements = append(entitlements, ent.NewPermissionEntitlement(resource, permissionType, entitlementOptions...))
 	}
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
 // Grants returns a slice of grants for each user and their set role under organization.
-func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	users, err := o.client.ListUsersByOrganization(ctx, resource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("airbyte-connector: failed to list users under organization %s: %w", resource.Id.Resource, err)
+		return nil, nil, fmt.Errorf("airbyte-connector: failed to list users under organization %s: %w", resource.Id.Resource, err)
 	}
 
 	var rv []*v2.Grant
@@ -120,7 +118,7 @@ func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagin
 		// Get the permission type for the user under the organization
 		permissionType, err := o.getOrganizationPermissionType(ctx, user.ID, resource.Id.Resource)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("airbyte-connector: failed to get permission type for user %s under organization %s: %w", user.ID, resource.Id.Resource, err)
+			return nil, nil, fmt.Errorf("airbyte-connector: failed to get permission type for user %s under organization %s: %w", user.ID, resource.Id.Resource, err)
 		}
 
 		// check for valid roles and skip if not
@@ -130,13 +128,13 @@ func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagin
 
 		userResource, err := userResource(user)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, grant.NewGrant(resource, permissionType, userResource.Id))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 func newOrgBuilder(client *airbyte.Client) *orgBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/conductorone/baton-airbyte/pkg/airbyte"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
@@ -48,16 +46,16 @@ func userResource(user *airbyte.User) (*v2.Resource, error) {
 }
 
 // List returns all the users as resource objects.
-func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
 	// The only way found to list all users was the list users endpoint with access information per workspace, since the list users endpoint does not work as we might expect..
 	// If we use the endpoint to list users by organization, we would lose the users who only have access to a single workspace.
 	ListUserResponse, err := o.client.ListUsersWithAccessInfoByWorkspace(ctx, parentResourceID.Resource)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("airbyte-connector: failed to list users: %w", err)
+		return nil, nil, fmt.Errorf("airbyte-connector: failed to list users: %w", err)
 	}
 
 	resources := make([]*v2.Resource, 0, len(ListUserResponse))
@@ -71,22 +69,22 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		ur, err := userResource(&user)
 
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("failed to create resource for user %s: %w", user.Email, err)
+			return nil, nil, fmt.Errorf("failed to create resource for user %s: %w", user.Email, err)
 		}
 		resources = append(resources, ur)
 	}
 
-	return resources, "", nil, nil
+	return resources, nil, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (o *userBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (o *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *userBuilder) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(client *airbyte.Client) *userBuilder {

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/conductorone/baton-airbyte/pkg/airbyte"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -74,7 +72,8 @@ func workspaceResource(workspace airbyte.Workspace, parentResourceID *v2.Resourc
 //
 // Workspaces belonging to organizations we can't access will be marked with an
 // "unknown-parent" organization ID.
-func (o *workspaceBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *workspaceBuilder) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	pToken := &opts.PageToken
 	// Initialize the map if we're starting a new list
 	if pToken.Token == "" {
 		// Initialize the map
@@ -83,7 +82,7 @@ func (o *workspaceBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *p
 		// Get workspaces with organizations
 		allWorkspacesWithParentOrganizationID, err := o.getAllWorkspacesWithParentOrganizationID(ctx)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("airbyte-connector: getAllWorkspacesWithParentOrganizationID > failed to list workspaces: %w", err)
+			return nil, nil, fmt.Errorf("airbyte-connector: getAllWorkspacesWithParentOrganizationID > failed to list workspaces: %w", err)
 		}
 
 		// Populate the map with workspace-to-organization relationships
@@ -99,17 +98,17 @@ func (o *workspaceBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *p
 	// pToken.Token is the offset for the current page
 	bag, offsetForCurrentPage, err := parsePageToken(pToken, &v2.ResourceId{ResourceType: workspaceResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	listWorkspaceResponse, offsetForNextPage, err := o.client.ListAllWorkspaces(ctx, ResourcesPageSize, offsetForCurrentPage)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("airbyte-connector: ListAllWorkspaces > failed to list workspaces: %w", err)
+		return nil, nil, fmt.Errorf("airbyte-connector: ListAllWorkspaces > failed to list workspaces: %w", err)
 	}
 
 	next, err := bag.NextToken(offsetForNextPage)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	// Process all workspaces
@@ -139,17 +138,17 @@ func (o *workspaceBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *p
 
 		resource, err := workspaceResource(workspace, parentResourceID)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("failed to create resource for workspace %s: %w", workspace.Name, err)
+			return nil, nil, fmt.Errorf("failed to create resource for workspace %s: %w", workspace.Name, err)
 		}
 
 		resources = append(resources, resource)
 	}
 
-	return resources, next, nil, nil
+	return resources, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
 // Entitlements returns a slice of entitlements for possible user roles under workspace (Viewer, Editor, Admin).
-func (o *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	// Preallocate slice for efficiency
 	entitlements := make([]*v2.Entitlement, 0, len(PublicWorkspacePermissionsTypes))
 
@@ -169,14 +168,14 @@ func (o *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resource
 		entitlements = append(entitlements, ent.NewPermissionEntitlement(resource, permissionType, entitlementOptions...))
 	}
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
 // Grants returns a slice of grants for each user and their set role under workspace.
-func (o *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (o *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	listUserswithaccessInfoResponse, err := o.client.ListUsersWithAccessInfoByWorkspace(ctx, resource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("airbyte-connector: failed to list users under workspace %s: %w", resource.Id.Resource, err)
+		return nil, nil, fmt.Errorf("airbyte-connector: failed to list users under workspace %s: %w", resource.Id.Resource, err)
 	}
 
 	// Map organization permissions to workspace permissions.
@@ -219,13 +218,13 @@ func (o *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, _ 
 
 		userResource, err := userResource(&user)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, grant.NewGrant(resource, permissionType, userResource.Id))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
 func newWorkspaceBuilder(client *airbyte.Client) *workspaceBuilder {


### PR DESCRIPTION
## Summary

- Migrate resource syncers to `ResourceSyncerV2` interface (V2 `SyncOpAttrs`/`SyncOpResults` signatures)
- Replace `config.DefineConfiguration` with `config.RunConnector` + `NewLambdaConnector`
- Add `WithDefaultCapabilitiesConnectorBuilderV2` to enable the `capabilities` subcommand required by `generate-baton-metadata.yaml`
- Update `config.go` with `WithConnectorDisplayName`, `WithIconUrl`, `WithHelpUrl`, display names, placeholders, and `WithIsSecret` matching C1 schema (`airbyte-client-id` is also secret)
- Update `Makefile` with `BATON_LAMBDA_SUPPORT` build tag
- Regenerate `conf.gen.go` and `baton_capabilities.json`

Closes CXH-1872

## Test plan

- [x] `go build ./...` succeeds
- [x] `go build -tags baton_lambda_support ./cmd/baton-airbyte` succeeds
- [x] `./connector capabilities` produces valid `baton_capabilities.json`
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)